### PR TITLE
read() parameter condition is not required

### DIFF
--- a/src/mongodbclient.ts
+++ b/src/mongodbclient.ts
@@ -83,7 +83,7 @@ export class MClient {
       },reject);
     });
   }
-  public read(condition:any,opt?:any){
+  public read(condition: any = {}, opt?:any){
     const that = this;
     return new Promise(function(resolve,reject){
       that.getConnected()

--- a/test/test.ts
+++ b/test/test.ts
@@ -32,12 +32,12 @@ describe("MClient", () => {
   });
 
   it("read()", async () => {
-    const docs = (await mdbc.read({})) as any[];
+    const docs = (await mdbc.read()) as any[];
     assert.equal(docs.length, items.length);
   });
 
   it("upsert()", async () => {
-    const docs = (await mdbc.read({})) as any[];
+    const docs = (await mdbc.read()) as any[];
     const { modifiedCount } = (await mdbc.upsert({ _id: docs[0]._id, name: "david" })) as { modifiedCount: number };
     assert.equal(modifiedCount, 1);
   });


### PR DESCRIPTION
read() can be called with no parameter.
``` diff
- mdbc.read({})
+ mdbc.read()
```
