### PR TITLE
count() parameter is not required now

### DIFF
--- a/src/mongodbclient.ts
+++ b/src/mongodbclient.ts
@@ -152,7 +152,7 @@ export class MClient {
       }, reject);
     });
   }
-  public count(condition:any){
+  public count(condition:any = {}){
     const that = this;
     return new Promise<number>(function(resolve,reject){
       that.getConnected()


### PR DESCRIPTION
``` diff
- mdbc.count({})
+ mdbc.count()
```